### PR TITLE
[fix] 修复sql语法错误导致docker部署异常问题。mysql注释--后必须带一个空格

### DIFF
--- a/docker/data/mysql/initdb/fastbee2.1.sql
+++ b/docker/data/mysql/initdb/fastbee2.1.sql
@@ -2033,7 +2033,7 @@ INSERT INTO `sys_dict_data` VALUES (774, 1, '消息重发', '1', 'rule_script_ac
 INSERT INTO `sys_dict_data` VALUES (775, 2, '消息通知', '2', 'rule_script_action', NULL, 'default', 'N', '0', 'admin', '2023-12-19 11:43:18', 'admin', '2023-12-19 11:43:38', NULL);
 INSERT INTO `sys_dict_data` VALUES (776, 3, 'Http推送', '3', 'rule_script_action', NULL, 'default', 'N', '0', 'admin', '2023-12-19 11:43:33', '', NULL, NULL);
 INSERT INTO `sys_dict_data` VALUES (777, 4, 'Mqtt桥接', '4', 'rule_script_action', NULL, 'default', 'N', '0', 'admin', '2023-12-19 11:43:54', '', NULL, NULL);
---视频模块新增字典
+-- 视频模块新增字典
 INSERT INTO `sys_dict_data` VALUES (169, 0, 'DVR', '111', 'video_type', NULL, 'default', 'N', '0', 'admin', '2023-02-22 01:07:06', '', NULL, NULL);
 INSERT INTO `sys_dict_data` VALUES (170, 1, 'NVR', '118', 'video_type', NULL, 'default', 'N', '0', 'admin', '2023-02-22 01:07:59', '', NULL, NULL);
 INSERT INTO `sys_dict_data` VALUES (171, 2, '报警控制器', '117', 'video_type', NULL, 'default', 'N', '0', 'admin', '2023-02-22 01:08:13', 'admin', '2023-02-22 01:08:35', NULL);


### PR DESCRIPTION
[issues#18 docker部署异常提示表不存在](https://github.com/kerwincui/FastBee/issues/18)